### PR TITLE
Fix broken link in project README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,6 @@ There are many more features in the works, see [checklist of currently supported
 
 ## Dirty Details
 
-If you want to look under the hood, see [kitchen.html](./ServerRoot/common/kitchen.html) (which is a version of *mashlib/dist/browse.html*) and the  [electron and CSS specific modifications](./src/).
+If you want to look under the hood, see [kitchen.html](./assets/kitchen.html) (which is a version of *mashlib/dist/browse.html*) and the  [electron and CSS specific modifications](./src/).
 
 copyright (c) 2021 Jeff Zucker, MIT license.


### PR DESCRIPTION
In 94cdc69932e40977ee3242f43f7d81dfea42812e the `kitchen.html` file was moved but the link to it in the project README was not updated.

This MR fixes that.